### PR TITLE
I see a repo and I want it painted black

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,6 +22,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.githubpages",
     "sphinx_copybutton",
+    "sphinx_rtd_dark_mode",
 ]
 
 templates_path = ["_templates"]
@@ -33,3 +34,9 @@ exclude_patterns = []
 
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
+
+
+# -- Custom configuration ----------------------------------------------------
+# user starts in dark mode
+default_dark_mode = True
+

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -4,6 +4,7 @@ ipdb==0.13.13
 sphinx==7.4.7
 sphinx-rtd-theme==2.0.0
 sphinx-copybutton==0.5.2
+sphinx-rtd-dark-mode==1.3.0
 pre-commit==4.0.1
 mypy==1.11.2
 ruff==0.7.0


### PR DESCRIPTION
Add dark theme to option (used by default) to the generated docs.

Just as it was in the song "Paint It Black" by "The Rolling Stones":

> I see a repo
> And I want it painted black
> No colors anymore
> I want them to turn black